### PR TITLE
Fix broken builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: ruby
+
 services:
   - postgresql
+
 before_install:
   - gem update --system
+
 before_script:
   - psql -c 'create database political_ties_test;' -U postgres


### PR DESCRIPTION
Attempting to address ` can't find gem bundler (>= 0.a) with executable bundle (Gem::GemNotFoundException)` occurring in Travis.